### PR TITLE
fix: disable injection autowiring for `WarmupForMapper` attribute

### DIFF
--- a/src/Cache/WarmupForMapper.php
+++ b/src/Cache/WarmupForMapper.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class WarmupForMapper extends Autoconfigure
 {
-    public function __construct(bool $autowire = true)
+    public function __construct(bool $autowire = false)
     {
         parent::__construct(tags: ['valinor.warmup'], autowire: $autowire);
     }

--- a/tests/Unit/Cache/WarmupForMapperTest.php
+++ b/tests/Unit/Cache/WarmupForMapperTest.php
@@ -15,7 +15,7 @@ final class WarmupForMapperTest extends TestCase
         $attributeWithAutowiring = new WarmupForMapper(true);
         $attributeWithoutAutowiring = new WarmupForMapper(false);
 
-        self::assertTrue($attributeWithoutArgument->autowire);
+        self::assertFalse($attributeWithoutArgument->autowire);
         self::assertTrue($attributeWithAutowiring->autowire);
         self::assertFalse($attributeWithoutAutowiring->autowire);
     }


### PR DESCRIPTION
This is a fix of the commit 2dc2b9301745a2633202779bf66325bd559c895f which did the opposite of what it was supposed to do. 🤦