### PR TITLE
POC failing test

### DIFF
--- a/tests/App/src/Objects/BasicObjectWithArrayShape.php
+++ b/tests/App/src/Objects/BasicObjectWithArrayShape.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\ValinorBundle\Tests\App\Objects;
+
+final class BasicObjectWithArrayShape
+{
+    /** @var array{basicObject: BasicObject|null} */
+    public array $foo;
+}

--- a/tests/Integration/MappingTest.php
+++ b/tests/Integration/MappingTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace CuyZ\ValinorBundle\Tests\Integration;
 
+use CuyZ\ValinorBundle\Tests\App\Objects\BasicObjectWithArrayShape;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
+
 final class MappingTest extends IntegrationTestCase
 {
     public function test_default_mapper_is_injected_and_works_properly(): void
@@ -40,5 +43,18 @@ final class MappingTest extends IntegrationTestCase
             ->map('mixed', 'foo');
 
         self::assertSame('foo', $result);
+    }
+
+    public function test_failing(): void
+    {
+        DebugClassLoader::enable();
+
+        $result = $this->mapperContainer()
+            ->defaultMapper
+            ->map(BasicObjectWithArrayShape::class, [
+                'foo' => [
+                    'basicObject' => null,
+                ]
+            ]);
     }
 }


### PR DESCRIPTION
This is something annoying when developing, but not sure if there could be a workaround or it should probably be done in the Symfony side.

```
RuntimeException: Case mismatch between loaded and declared class names: "CuyZ\ValinorBundle\Tests\App\Objects\basicObject" vs "CuyZ\ValinorBundle\Tests\App\Objects\BasicObject".
```

The problem seems that Symfony intercepts `class_exists` call and throws an exception because it detects a class in the same folder but different name (Case mismatch).

https://github.com/symfony/symfony/blob/e711f3ed12fafbe49fc087919c1c4cc538b1ede7/src/Symfony/Component/ErrorHandler/DebugClassLoader.php#L331