### PR TITLE
fix: automatically register cache for normalizer builder

### DIFF
--- a/src/Configurator/CacheConfigurator.php
+++ b/src/Configurator/CacheConfigurator.php
@@ -6,9 +6,10 @@ namespace CuyZ\ValinorBundle\Configurator;
 
 use CuyZ\Valinor\Cache\Cache;
 use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\NormalizerBuilder;
 
 /** @internal */
-final class CacheConfigurator implements MapperBuilderConfigurator
+final class CacheConfigurator implements MapperBuilderConfigurator, NormalizerBuilderConfigurator
 {
     public function __construct(
         /** @var Cache<mixed> */
@@ -16,6 +17,11 @@ final class CacheConfigurator implements MapperBuilderConfigurator
     ) {}
 
     public function configureMapperBuilder(MapperBuilder $builder): MapperBuilder
+    {
+        return $builder->withCache($this->cache);
+    }
+
+    public function configureNormalizerBuilder(NormalizerBuilder $builder): NormalizerBuilder
     {
         return $builder->withCache($this->cache);
     }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -115,6 +115,7 @@ return static function (ContainerConfigurator $container, ContainerBuilder $buil
 
         ->set(null, CacheConfigurator::class)
             ->tag('valinor.mapper_builder_configurator')
+            ->tag('valinor.normalizer_builder_configurator')
             ->args([service($config['cache']['service'])])
 
         ->set(null, DateFormatsConfigurator::class)


### PR DESCRIPTION
It was an oversight during the release of 2.0 where the `MapperBuilder` was split out with the `NormalizerBuilder`.